### PR TITLE
Fix Empty string being unserialized as current DateTime

### DIFF
--- a/src/Opensoft/SimpleSerializer/Adapter/ArrayAdapter.php
+++ b/src/Opensoft/SimpleSerializer/Adapter/ArrayAdapter.php
@@ -220,6 +220,9 @@ class ArrayAdapter implements BaseArrayAdapter
                     }
                     $value = $value->format($dateTimeFormat);
                 } elseif ($direct == self::DIRECTION_UNSERIALIZE) {
+                    if (trim($value) === "") {
+                        throw new InvalidArgumentException(sprintf('Invalid DateTime argument "%s"', $value));
+                    }
                     try {
                         $value = new DateTime($value);
                     } catch (\Exception $e) {

--- a/tests/Opensoft/SimpleSerializer/Tests/Adapter/ArrayAdapterTest.php
+++ b/tests/Opensoft/SimpleSerializer/Tests/Adapter/ArrayAdapterTest.php
@@ -406,6 +406,15 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($result->getHiddenStatus());
     }
 
+    /**
+     * @expectedException \Opensoft\SimpleSerializer\Exception\InvalidArgumentException
+     */
+    public function testToObjectDateTimeInvalidArgument()
+    {
+        $object = new TestDateTime();
+        $this->unitUnderTest->toObject(array('emptyDateTimeFormat' => ""), $object);
+    }
+
     public function testNonStrictUnserializeHasExtraFields()
     {
         $this->unitUnderTest->setUnserializeMode(0);


### PR DESCRIPTION
Throw InvalidArgumentException if trying to unserialize empty string as DateTime object

As can be seen, if object field is described as being of a DateTime type and someone is trying to unserialize an empty string to this field, then instead of an error message we get that field set to current date time.
